### PR TITLE
updated to remove javadoc tags

### DIFF
--- a/java/HelloWorld.java
+++ b/java/HelloWorld.java
@@ -1,12 +1,16 @@
 /**
 * A class to print out "Hello, world!"
 * Another line
-*@user, a tag for removal
+* @user, a tag for removal
 */
+
+
 class HelloWorld {
     /**
     * Prints out "Hello, world!"
     */
+
+    
     public static void main(String args[]) {
         System.out.println("Hello, world!");    // print statement
     }

--- a/java/HelloWorld.java
+++ b/java/HelloWorld.java
@@ -1,6 +1,7 @@
 /**
 * A class to print out "Hello, world!"
 * Another line
+*@user, a tag for removal
 */
 class HelloWorld {
     /**

--- a/parse_comments.py
+++ b/parse_comments.py
@@ -2,18 +2,22 @@
 # References:
 # https://stackoverflow.com/questions/15423658/regular-expression-for-single-line-comments
 # https://blog.ostermiller.org/find-comment
+
+
 """Parse comments from a Java source code file."""
 import re
 import java_parser
+
 
 FILE_SEPARATOR = "/"
 MULTILINECOMMENT_RE = r'\/\*+([\s\S]*?)\*+\/'
 SINGLELINECOMMENT_RE_JAVA = \
     r'^(?:[^"/\\]|\"(?:[^\"\\]|\\.)*\"|/(?:[^/"\\]|\\.)|/\"(?:[^\"\\]|\\.)*\"|\\.)*//(.*)$'
 
+
 def nix_javadoc_tags(java_string):
     """Removes javadoc tags such as @author from the source comments"""
-    post_nix = re.sub('.@.*? ','', java_string)
+    post_nix = re.sub('.@.*? ', ' ', java_string)
     return post_nix
 
 
@@ -71,6 +75,7 @@ if __name__ == "__main__":
 
     with open('./java/HelloWorld.java', 'r') as java_file:
         JAVA_STRING = java_file.read()
+
     comment = nix_javadoc_tags(JAVA_STRING)
     print("\nComments w/out Javadoc tags\n-------------------")
     print(repr(comment))

--- a/parse_comments.py
+++ b/parse_comments.py
@@ -6,11 +6,15 @@
 import re
 import java_parser
 
-
 FILE_SEPARATOR = "/"
 MULTILINECOMMENT_RE = r'\/\*+([\s\S]*?)\*+\/'
 SINGLELINECOMMENT_RE_JAVA = \
     r'^(?:[^"/\\]|\"(?:[^\"\\]|\\.)*\"|/(?:[^/"\\]|\\.)|/\"(?:[^\"\\]|\\.)*\"|\\.)*//(.*)$'
+
+def nix_javadoc_tags(java_string):
+    """Removes javadoc tags such as @author from the source comments"""
+    post_nix = re.sub('.@.*? ','', java_string)
+    return post_nix
 
 
 def list_singleline_java_comments(java_string):
@@ -67,6 +71,10 @@ if __name__ == "__main__":
 
     with open('./java/HelloWorld.java', 'r') as java_file:
         JAVA_STRING = java_file.read()
+    comment = nix_javadoc_tags(JAVA_STRING)
+    print("\nComments w/out Javadoc tags\n-------------------")
+    print(repr(comment))
+    str(nix_javadoc_tags(JAVA_STRING))
 
     COMMENTS = list_singleline_java_comments(JAVA_STRING)
     print("\nSingleline comments\n-------------------")

--- a/tests/test_parse_comments_ratios.py
+++ b/tests/test_parse_comments_ratios.py
@@ -5,6 +5,8 @@ import parse_comments as pc
 JAVA_STRING = """/**
 * A class to print out "Hello, world!"
 * Another line
+*@user, a tag for removal
+*@blahfenshtele, another tag for removal
 */
 class HelloWorld {
     /**
@@ -28,3 +30,8 @@ def test_get_ratio_of_multiline_comments_to_source_code_with_two_comments():
     actual_ratio = \
         pc.get_ratio_of_multiline_comments_to_source_code(JAVA_STRING)
     assert actual_ratio == 0.4
+
+def test_get_javadoc_tag_nixed_code_comments():
+    final_form = pc.nix_javadoc_tags(JAVA_STRING)
+    assert "@user," not in final_form
+    assert "@blahfenshtele," not in final_form

--- a/tests/test_parse_comments_ratios.py
+++ b/tests/test_parse_comments_ratios.py
@@ -31,6 +31,7 @@ def test_get_ratio_of_multiline_comments_to_source_code_with_two_comments():
         pc.get_ratio_of_multiline_comments_to_source_code(JAVA_STRING)
     assert actual_ratio == 0.4
 
+
 def test_get_javadoc_tag_nixed_code_comments():
     final_form = pc.nix_javadoc_tags(JAVA_STRING)
     assert "@user," not in final_form


### PR DESCRIPTION
Should work properly, running from the @ symbol to the first space and replacing it with a space. test suite passes.