### PR TITLE
Refactoring for PEP8 style guide compliance

### DIFF
--- a/analyze_java.py
+++ b/analyze_java.py
@@ -49,7 +49,7 @@ def analyze_java(java_strings):
     list_list["methods"] = methodList
     list_list["classes"] = classList
     list_list["lines"] = lineList
-    statistics.printStatistics(list_list)
+    statistics.print_statistics(list_list)
 
 
 def get_file_paths(Type, location):

--- a/analyze_java.py
+++ b/analyze_java.py
@@ -1,64 +1,67 @@
+""" analyze java source code """
+
+import os
+import statistics
 import java_to_string as j
 import java_parser as p
-import statistics
-import os
 
 
 def get_java_strings(out):
+    """ return java source code strings """
     java_files = get_file_paths(".java", out)
-    repoDict = dict()
-    for f in java_files:
+    repo_dict = dict()
+    for file in java_files:
         # The second replace is so that code doesn't break on windows
-        currFile = f.replace(out, "").replace("\\", "/")
-        repo = currFile.split("/")[1]
-        if repo in repoDict:
+        curr_file = file.replace(out, "").replace("\\", "/")
+        repo = curr_file.split("/")[1]
+        if repo in repo_dict:
             continue
         files = []
-        for javaFile in java_files:
-            if repo in javaFile:
-                files.append(javaFile)
-        repoDict[repo] = files
-
+        for java_file in java_files:
+            if repo in java_file:
+                files.append(java_file)
+        repo_dict[repo] = files
     java_strings = []
-
-    for key, values in repoDict.items():
+    for _, values in repo_dict.items():
         java_string = []
         for value in values:
             java_string.append(j.read_and_convert(value))
         java_strings.append(' '.join(java_string))
-
     return java_strings
 
 
 def analyze_java(java_strings):
-    variableList = []
-    methodList = []
-    classList = []
-    lineList = []
+    """ analyze java source code strings """
+    variable_list = []
+    method_list = []
+    class_list = []
+    line_list = []
     list_list = dict()
     for java_string in java_strings:
         java_string = j.remove_comments(java_string)
         try:
-            variableList.append(p.get_number_of_variables(java_string))
-            methodList.append(p.get_number_of_methods(java_string))
-            classList.append(p.get_number_of_classes(java_string))
-            lineList.append(p.get_number_of_lines(java_string))
-        except(Exception):
+            variable_list.append(p.get_number_of_variables(java_string))
+            method_list.append(p.get_number_of_methods(java_string))
+            class_list.append(p.get_number_of_classes(java_string))
+            line_list.append(p.get_number_of_lines(java_string))
+        except Exception:
             pass
-    list_list["variables"] = variableList
-    list_list["methods"] = methodList
-    list_list["classes"] = classList
-    list_list["lines"] = lineList
+    list_list["variables"] = variable_list
+    list_list["methods"] = method_list
+    list_list["classes"] = class_list
+    list_list["lines"] = line_list
     statistics.print_statistics(list_list)
 
 
-def get_file_paths(Type, location):
+def get_file_paths(filetype, location):
+    """ return list of filepaths """
     list_of_files = list()
-    for subdir, dirs, files in os.walk(location):
+    for subdir, _dirs, files in os.walk(location):
         for file in files:
             file = subdir + "/" + file
-            if file.endswith(Type):
+            if file.endswith(filetype):
                 list_of_files.append(file)
     return list_of_files
 
-#analyze_java(get_java_strings("."))
+
+# analyze_java(get_java_strings("."))

--- a/analyze_java.py
+++ b/analyze_java.py
@@ -39,10 +39,10 @@ def analyze_java(java_strings):
     for java_string in java_strings:
         java_string = j.remove_comments(java_string)
         try:
-            variableList.append(p.getNumberOfVariables(java_string))
-            methodList.append(p.getNumberOfMethods(java_string))
-            classList.append(p.getNumberOfClasses(java_string))
-            lineList.append(p.getNumberOfLines(java_string))
+            variableList.append(p.get_number_of_variables(java_string))
+            methodList.append(p.get_number_of_methods(java_string))
+            classList.append(p.get_number_of_classes(java_string))
+            lineList.append(p.get_number_of_lines(java_string))
         except(Exception):
             pass
     list_list["variables"] = variableList

--- a/analyze_sentiment.py
+++ b/analyze_sentiment.py
@@ -1,4 +1,5 @@
 """Perform sentiment analysis on strings with the NLTK library."""
+
 from nltk.sentiment.vader import SentimentIntensityAnalyzer
 
 COMPOUND_KEY = "compound"
@@ -8,17 +9,22 @@ POSITIVE_KEY = "pos"
 
 
 def get_sentence_sentiment(sentence):
-    """Return dictionary with keys "compound", "neg", "neu", and "pos" whose values are the sentiment scores."""
+    """Return dictionary with keys "compound", "neg", "neu", and "pos" whose
+    values are the sentiment scores."""
     sid = SentimentIntensityAnalyzer()
     sentiment_scores = sid.polarity_scores(sentence)
     return sentiment_scores
 
 
 def get_avg_sentiment(list_of_comments):
-    """Return average compound, negative, neutral, and positive sentiment of comments in a list."""
-
+    """Return average compound, negative, neutral, and positive sentiment of
+    comments in a list."""
     if not list_of_comments or list_of_comments == []:
-        zero_dict = {COMPOUND_KEY: 0, NEGATIVE_KEY: 0, NEUTRAL_KEY: 0, POSITIVE_KEY: 0}
+        zero_dict = {
+            COMPOUND_KEY: 0,
+            NEGATIVE_KEY: 0,
+            NEUTRAL_KEY: 0,
+            POSITIVE_KEY: 0}
         return zero_dict
 
     comment_counter = 0
@@ -35,9 +41,10 @@ def get_avg_sentiment(list_of_comments):
         positive_total += sentiment[POSITIVE_KEY]
         comment_counter += 1
 
-    avg_sentiment = {COMPOUND_KEY: (compound_total / comment_counter),
-                     NEGATIVE_KEY: (negative_total / comment_counter),
-                     NEUTRAL_KEY: (neutral_total / comment_counter),
-                     POSITIVE_KEY: (positive_total / comment_counter)}
+    avg_sentiment = {
+        COMPOUND_KEY: (compound_total / comment_counter),
+        NEGATIVE_KEY: (negative_total / comment_counter),
+        NEUTRAL_KEY: (neutral_total / comment_counter),
+        POSITIVE_KEY: (positive_total / comment_counter)}
 
     return avg_sentiment

--- a/defaults.py
+++ b/defaults.py
@@ -1,3 +1,5 @@
+""" configuration defaults and modifications """
+
 import configparser
 import os
 
@@ -26,7 +28,7 @@ def new_config():
     with open('./config.ini', 'w') as config_file:
         config.write(config_file)
 
-        
+
 def edit_config():
     """Allow user to edit each value in the config file."""
     ask_prefix = str(

--- a/display.py
+++ b/display.py
@@ -1,13 +1,15 @@
-"""Format and return strings to display.  Used the format from Accelegator for this file"""
-from colors import bold
+"""Format and return strings to display.  Used the format from Accelegator for
+this file"""
+
 import logging
 import textwrap
-# local import
+from colors import bold
 import display_strings
 
 
 def display_help_with_command(command):
-    """Return a string with verbose description and valid arguments for a command."""
+    """Return a string with verbose description and valid arguments for a
+    command."""
     command_functions = {
         "help": display_help_help,
         "get": display_get_help,
@@ -21,6 +23,7 @@ def display_help_with_command(command):
 
 
 def display_help_help():
+    """ display help for the help command """
     command_one_tuple = (display_strings.HELP_HEADER,
                          display_strings.HELP_COMMAND_ONE,
                          display_strings.HELP_DESCRIPTION_ONE,
@@ -36,6 +39,7 @@ def display_help_help():
 
 
 def display_get_help():
+    """ display help for the get command """
     command_tuple = (display_strings.GET_HEADER,
                      display_strings.GET_COMMAND_ONE,
                      display_strings.GET_DESCRIPTION_ONE,
@@ -47,6 +51,7 @@ def display_get_help():
 
 
 def display_config_help():
+    """ display help for the config command """
     command_one_tuple = (display_strings.CONFIG_HEADER,
                          display_strings.CONFIG_COMMAND_ONE,
                          display_strings.CONFIG_DESCRIPTION_ONE,
@@ -64,6 +69,7 @@ def display_config_help():
 
 
 def display_list_help():
+    """ display help for the list command """
     command_one_tuple = (display_strings.LIST_HEADER,
                          display_strings.LIST_COMMAND_ONE,
                          display_strings.LIST_DESCRIPTION_ONE,
@@ -80,6 +86,7 @@ def display_list_help():
 
 
 def display_analyze_help():
+    """ display help for the analyze command """
     command_one_tuple = (display_strings.ANALYZE_HEADER,
                          display_strings.ANALYZE_COMMAND_ONE,
                          display_strings.ANALYZE_DESCRIPTION_ONE,
@@ -90,6 +97,7 @@ def display_analyze_help():
 
 
 def display_quit_help():
+    """ display help for the quit command """
     command_tuple = (display_strings.QUIT_HEADER,
                      display_strings.QUIT_COMMAND,
                      display_strings.QUIT_DESCRIPTION,
@@ -99,34 +107,35 @@ def display_quit_help():
 
 
 def format_command_description(
-        command_one_tuple, command_two_tuple=None, command_three_tuple=None, command_four_tuple=None):
+        command_one_tuple, command_two_tuple=None,
+        command_three_tuple=None, command_four_tuple=None):
+    """ format command descriptions """
     logging.info("Formatting first command")
     header = bold(command_one_tuple[0])
     command_one = command_one_tuple[1]
     description_one = command_one_tuple[2]
     arguments_one = command_one_tuple[3]
-    command_one_string = header + "\n" + display_strings.COMMAND_LABEL + command_one + "\n" + \
-        display_strings.DESCRIPTION_LABEL + description_one + "\n" + \
-        display_strings.ARGUMENTS_LABEL + arguments_one + "\n"
-
+    command_one_string = header + "\n" + display_strings.COMMAND_LABEL + \
+        command_one + "\n" + display_strings.DESCRIPTION_LABEL + \
+        description_one + "\n" + display_strings.ARGUMENTS_LABEL + \
+        arguments_one + "\n"
     if command_two_tuple is not None:
         logging.info("Formatting second command")
         command_two = command_two_tuple[0]
         description_two = command_two_tuple[1]
         arguments_two = command_two_tuple[2]
-        command_two_string = display_strings.COMMAND_LABEL + command_two + "\n" + display_strings.DESCRIPTION_LABEL + \
-            description_two + "\n" + display_strings.ARGUMENTS_LABEL + arguments_two + "\n"
+        command_two_string = display_strings.COMMAND_LABEL + command_two + \
+            "\n" + display_strings.DESCRIPTION_LABEL + \
+            description_two + "\n" + display_strings.ARGUMENTS_LABEL + \
+            arguments_two + "\n"
         return command_one_string + "\n" + command_two_string
-    else:
-        return command_one_string
+    return command_one_string
 
 
 def display_help():
     """Return a string with a list of commands and their brief descriptions."""
     logging.info("Creating help string")
-
     help_string = ""
-
     for current_index, command_tuple in enumerate(
             display_strings.COMMANDS_LIST):
         left = command_tuple[0]
@@ -145,17 +154,16 @@ def display_help():
                     description_line = "\t" + description_line
                     help_string += "{:<30s}{:<40s}".format(
                         empty_space, description_line) + "\n"
-
     return help_string
 
 
 def align(left, right, is_negative_timestamp=False):
-    """Return string with "left" aligned to the left and "right" aligned to the right."""
+    """Return string with "left" aligned to the left and "right" aligned to the
+    right."""
     if is_negative_timestamp:
         logging.debug(
             "Moving right over 8 characters to account for ansi sequence")
         # adjust right alignment of inverted timestamp to account for ansi
         # sequence
         return "{:<40s}{:>48s}".format(left, right)
-    else:
-        return "{:<40s}{:>40s}".format(left, right)
+    return "{:<40s}{:>40s}".format(left, right)

--- a/display.py
+++ b/display.py
@@ -128,7 +128,7 @@ def display_help():
     help_string = ""
 
     for current_index, command_tuple in enumerate(
-            display_strings.commands_list):
+            display_strings.COMMANDS_LIST):
         left = command_tuple[0]
         right = command_tuple[1]
         if current_index is 0:

--- a/display_strings.py
+++ b/display_strings.py
@@ -42,19 +42,19 @@ HELP_ARGUMENTS_ONE = "None"
 
 HELP_COMMAND_TWO = "help <command>"
 HELP_DESCRIPTION_TWO = \
-        "Show verbose description of usage " + \
-        "and show valid arguments for <command>"
+    "Show verbose description of usage " + \
+    "and show valid arguments for <command>"
 HELP_ARGUMENTS_TWO = \
-        "<command>: Command to show description " + \
-        "and valid arguments for.\nCan be any of the following:\n\t" + \
-        "\n\t".join(COMMANDS)
+    "<command>: Command to show description " + \
+    "and valid arguments for.\nCan be any of the following:\n\t" + \
+    "\n\t".join(COMMANDS)
 
 # get help info, preparing to add other arguments
 GET_HEADER = "get\n----"
 GET_COMMAND_ONE = "get"
 GET_DESCRIPTION_ONE = \
-        "Downloads repositories from Project " + \
-        "with specified Prefix to directory Out"
+    "Downloads repositories from Project " + \
+    "with specified Prefix to directory Out"
 GET_ARGUMENTS_ONE = "None"
 
 # config help info
@@ -81,8 +81,8 @@ LIST_ARGUMENTS_TWO = "<repo name>"
 ANALYZE_HEADER = "analyze\n----"
 ANALYZE_COMMAND_ONE = "analyze <target>"
 ANALYZE_DESCRIPTION_ONE = \
-        "Performs analysis for specified target " + \
-        "('source','comments','commits','reflection')"
+    "Performs analysis for specified target " + \
+    "('source','comments','commits','reflection')"
 ANALYZE_ARGUMENTS_ONE = "<target>"
 
 # quit help info

--- a/display_strings.py
+++ b/display_strings.py
@@ -1,31 +1,35 @@
-"""Define strings that will be displayed by the REPL.  Used the format from Accelegator for this file"""
+"""Define strings that will be displayed by the REPL.  Used the format from
+Accelegator for this file"""
+
 from colors import bold
 
 # Help display strings
-commands_list = []
-commands_list.append((bold("Command"), bold("Description")))
+COMMANDS_LIST = []
+COMMANDS_LIST.append((bold("Command"), bold("Description")))
 # add help info
-commands_list.append(("help", "List commands and their brief descriptions"))
-commands_list.append(
-    ("help <command>",
-     "List verbose description of <command> and show valid arguments for <command>"))
+COMMANDS_LIST.append(("help", "List commands and their brief descriptions"))
+COMMANDS_LIST.append(
+    ("help <command>", "List verbose description of <command> " +
+     "and show valid arguments for <command>"))
 # add get info
-commands_list.append(
-    ("get", "Downloads repositories from Project with specified Prefix to directory Out"))
+COMMANDS_LIST.append(
+    ("get", "Downloads repositories from Project " +
+     "with specified Prefix to directory Out"))
 # add config info
-commands_list.append(("config", "Print the values in the config file"))
-commands_list.append(
+COMMANDS_LIST.append(("config", "Print the values in the config file"))
+COMMANDS_LIST.append(
     ("config <option>",
      "Edit or reset the values in the config file"))
 # add list info
-commands_list.append(("list", "Lists all files"))
-commands_list.append(
+COMMANDS_LIST.append(("list", "Lists all files"))
+COMMANDS_LIST.append(
     ("list <repo name>", "Lists all files in the inputted repository"))
 # add analyze info
-commands_list.append(
-    ("analyze <target>", "Performs analysis for specified target ('source','comments','commits','reflection')"))
+COMMANDS_LIST.append(
+    ("analyze <target>", "Performs analysis for specified target " +
+     "('source','comments','commits','reflection')"))
 # add quit info
-commands_list.append(("quit", "Exit the program"))
+COMMANDS_LIST.append(("quit", "Exit the program"))
 
 # Help with command display strings
 COMMANDS = ["help", "get", "config", "list", "analyze", "quit"]
@@ -37,14 +41,20 @@ HELP_DESCRIPTION_ONE = "List commands and their brief descriptions"
 HELP_ARGUMENTS_ONE = "None"
 
 HELP_COMMAND_TWO = "help <command>"
-HELP_DESCRIPTION_TWO = "Show verbose description of usage and show valid arguments for <command>"
-HELP_ARGUMENTS_TWO = "<command>: Command to show description and valid arguments for.\nCan be any of the following:\n\t" + \
-    "\n\t".join(COMMANDS)
+HELP_DESCRIPTION_TWO = \
+        "Show verbose description of usage " + \
+        "and show valid arguments for <command>"
+HELP_ARGUMENTS_TWO = \
+        "<command>: Command to show description " + \
+        "and valid arguments for.\nCan be any of the following:\n\t" + \
+        "\n\t".join(COMMANDS)
 
 # get help info, preparing to add other arguments
 GET_HEADER = "get\n----"
 GET_COMMAND_ONE = "get"
-GET_DESCRIPTION_ONE = "Downloads repositories from Project with specified Prefix to directory Out"
+GET_DESCRIPTION_ONE = \
+        "Downloads repositories from Project " + \
+        "with specified Prefix to directory Out"
 GET_ARGUMENTS_ONE = "None"
 
 # config help info
@@ -70,7 +80,9 @@ LIST_ARGUMENTS_TWO = "<repo name>"
 # gensim help info (started, will finish with integration with repl)
 ANALYZE_HEADER = "analyze\n----"
 ANALYZE_COMMAND_ONE = "analyze <target>"
-ANALYZE_DESCRIPTION_ONE = "Performs analysis for specified target ('source','comments','commits','reflection')"
+ANALYZE_DESCRIPTION_ONE = \
+        "Performs analysis for specified target " + \
+        "('source','comments','commits','reflection')"
 ANALYZE_ARGUMENTS_ONE = "<target>"
 
 # quit help info

--- a/download_vader_lexicon.py
+++ b/download_vader_lexicon.py
@@ -1,2 +1,4 @@
+""" download nltk dictionary dependency """
+# execute with: python3 download_vader_lexicon.py
 import nltk
 nltk.download("vader_lexicon")

--- a/file_list.py
+++ b/file_list.py
@@ -1,11 +1,15 @@
-""" list all of the repositories in Out or all of the files in a given repository """
+""" list all of the repositories in Out or all of the files in a given
+repository """
+
 import os
 
 
 def list_files(repo, out):
+    """ list all of the repositories in Out or all of the files in a given
+    repository """
     repo_list = list()  # list of file names to return
     if repo is not "all" and not os.path.isdir(
-            "./" + str(out) + "/" + str(repo)):  # check if file location exists
+            "./" + str(out) + "/" + str(repo)):  # check if location exists
         print(
             "\tERROR: Repository: '" +
             str(repo) +
@@ -15,7 +19,8 @@ def list_files(repo, out):
         # list of all directories inside of Out folder
         repo_list = next(os.walk("./" + str(out)))[1]
     else:
-        for subdir, dirs, files in os.walk("./" + str(out) + "/" + str(repo)):
+        for _subdir, _dirs, files in \
+                os.walk("./" + str(out) + "/" + str(repo)):
             for file in files:
                 if "." in file:  # ignore files with no '.' extension
                     if file not in repo_list:  # get each unique file name

--- a/get_list_of_commits.py
+++ b/get_list_of_commits.py
@@ -1,20 +1,15 @@
+""" generate list of commit messages """
+
 from dulwich import porcelain
 
 
 def get_list_of_commits(file_path):
-    """Write a list of commit messages.
-
-    :param repo: Path to repository
-    """
-
-    list = []
-
-    with porcelain.open_repo_closing(file_path) as r:
-        walker = r.get_walker(reverse=True)
-
+    """Write a list of commit messages."""
+    return_list = []
+    with porcelain.open_repo_closing(file_path) as repo:
+        walker = repo.get_walker(reverse=True)
     for entry in walker:
         item = str(entry.commit.message.decode())
         item = item.replace("\n", "")
-        list.append(item)
-
-    return list
+        return_list.append(item)
+    return return_list

--- a/get_reflection.py
+++ b/get_reflection.py
@@ -1,18 +1,20 @@
 """ reads through and creates a list of lists from inputted file
     can be adapted to fit other group needs """
+
 import re
 
 
-def get_reflection(filePath):
-    with open(filePath, 'r') as reflection:
-        # to add additional file types just use the .endswith() function to specifiy the file type
-        # then add in how the file should be broken up into a list with the .split() function or
-        # whatever functionality is needed
-        if filePath.endswith(".md"):
-            # removes newline characters and breaks up file into sentences for
-            # NLP analysis
+def get_reflection(file_path):
+    """ reads through and creates a list of lists from inputted file """
+    with open(file_path, 'r') as reflection:
+        # to add additional file types just use the .endswith() function to
+        # specifiy the file type then add in how the file should be broken up
+        # into a list with the .split() function or whatever functionality is
+        # needed
+        if file_path.endswith(".md"):
+            # removes newline characters and breaks up file into sentences
             content = reflection.read()
             # removes special characters
-            content = re.sub('[^a-zA-Z0-9\*\^\(\)\'\-\n\.]', ' ', content)
+            content = re.sub(r'[^a-zA-Z0-9\*\^\(\)\'\-\n\.]', ' ', content)
             content.split('. ')
     return content  # list of lists

--- a/github_clone_all.py
+++ b/github_clone_all.py
@@ -1,17 +1,19 @@
-# github-clone-all.py
-# Dan Wallach <dwallach@rice.edu>
+""" github-clone-all.py
+Modified from original version by Dan Wallach <dwallach@rice.edu>.
+"""
 
-import requests
 import sys
 import os
 import subprocess
 import time
+import requests
+
 
 # TODO: make keywords a list of keywords to search for in the name of the
 # github repositories
 
 
-def get_repositories(githubToken, githubProject, keywords, outDir):
+def get_repositories(github_token, github_project, keywords, out_dir):
     #
     # local goodies (for my cron job)
     #
@@ -27,38 +29,39 @@ def get_repositories(githubToken, githubProject, keywords, outDir):
     print(">>>>>>>>>>>>>>")
     print("")
 
-    requestHeaders = {
+    request_headers = {
         "User-Agent": "GitHubCloneAll/1.0",
-        "Authorization": "token " + githubToken,
+        "Authorization": "token " + github_token,
     }
 
-    allReposList = []
+    all_repos_list = []
 
-    pageNumber = 1
+    page_number = 1
     sys.stdout.write('Getting repo list from Github')
 
     while True:
         sys.stdout.write('.')
         sys.stdout.flush()
-        reposPage = requests.get(
+        repos_page = requests.get(
             'https://api.github.com/orgs/' +
-            githubProject +
+            github_project +
             '/repos?page=' +
-            str(pageNumber),
-            headers=requestHeaders)
-        pageNumber = pageNumber + 1
+            str(page_number),
+            headers=request_headers)
+        page_number = page_number + 1
 
-        if reposPage.status_code != 200:
-            print("Failed to load repos from GitHub: " + str(reposPage.content))
+        if repos_page.status_code != 200:
+            print("Failed to load repos from GitHub: " +
+                  str(repos_page.content))
             return
 
-        reposPageJson = reposPage.json()
+        repos_page_json = repos_page.json()
 
-        if len(reposPageJson) == 0:
+        if not repos_page_json:
             print(" Done.")
             break
 
-        allReposList = allReposList + reposPage.json()
+        all_repos_list = all_repos_list + repos_page.json()
 
     # Each repo in the list has the following fields that we care about:
     #
@@ -72,36 +75,37 @@ def get_repositories(githubToken, githubProject, keywords, outDir):
     # full_name: the project and repo (e.g.,
     # 'RiceComp215/comp215-week01-intro-2017-dwallach')
 
-    filteredRepoList = [
-        x for x in allReposList if all(key in x['name'] for key in keywords)]  # attempt to check for all keywords in name
-    print(str(len(filteredRepoList)) +
-          " of " +
-          str(len(allReposList)) +
-          " repos start with " +
-          str(keywords))
+    # attempt to check for all keywords in name
+    filtered_repo_list = [
+        x for x in all_repos_list
+        if all(key in x['name']
+               for key in keywords)]
+    print(str(len(filtered_repo_list)) + " of " +
+          str(len(all_repos_list)) + " repos start with " + str(keywords))
     time.sleep(2)
     # before we start getting any repos, we need a directory to get them
-    if outDir != ".":
+    if out_dir != ".":
         try:
-            os.makedirs(outDir)
+            os.makedirs(out_dir)
         except OSError:
             # directory probably already exists
             print(
                 "Directory '" +
-                str(outDir) +
+                str(out_dir) +
                 "' already exists, please wait while directory is deleted\n")
-            # deletes outDir folder if it already exists
-            command = 'rm -r -f ./' + str(outDir)
+            # deletes out_dir folder if it already exists
+            command = 'rm -r -f ./' + str(out_dir)
             os.system(command)
-            os.makedirs(outDir)
-        os.chdir(outDir)
+            os.makedirs(out_dir)
+        os.chdir(out_dir)
 
     # specific clone instructions here:
     # https://github.com/blog/1270-easier-builds-and-deployments-using-git-over-https-and-oauth
-    repoNum = 1
-    for repo in filteredRepoList:
-        cloneUrl = 'https://' + \
-            str(githubToken) + '@github.com/' + str(repo['full_name']) + '.git'
+    repo_num = 1
+    for repo in filtered_repo_list:
+        clone_url = 'https://' + \
+            str(github_token) + '@github.com/' + \
+            str(repo['full_name']) + '.git'
 
         # Steps to take, per docs above:
         #
@@ -120,15 +124,16 @@ def get_repositories(githubToken, githubProject, keywords, outDir):
         subprocess.call(["git", "init"])
         print(">>>>>>>>>>>>>>")
         print(">>>>>>>>>>>>>> Downloading repository number " +
-              str(repoNum) + " of " + str(len(filteredRepoList)) + " repositories")
+              str(repo_num) + " of " + str(len(filtered_repo_list)) +
+              " repositories")
         print(">>>>>>>>>>>>>>")
-        subprocess.call(["git", "pull", cloneUrl])
+        subprocess.call(["git", "pull", clone_url])
         os.chdir('..')
-        repoNum += 1
+        repo_num += 1
 
     #
     # leftover from an earlier emergency: if you want to make a repo be private, here's the code to do it
     #
-    #         response = requests.patch('https://api.github.com/repos' + githubProject + '/' + name,
-    #                                   headers = requestHeaders, json={ "private": True })
+    #         response = requests.patch('https://api.github.com/repos' + github_project + '/' + name,
+    #                                   headers = request_headers, json={ "private": True })
     #

--- a/java_parser.py
+++ b/java_parser.py
@@ -1,45 +1,42 @@
-"""
-Functions to get statistics about parsed java files. Expects all parameter inputs
-to be java source code strings with all spaces, new lines, and comments removed.
-Requirement:
-pip install javalang
-"""
+""" Functions to get statistics about parsed java files. Expects all parameter
+inputs to be java source code strings with all spaces, new lines, and comments
+removed. Requirement: `pip install javalang` """
 
 
 import javalang
 
 
-def getNumberOfVariables(javaString):
+def get_number_of_variables(java_string):
     """ Counts number of declared variables in java code string using
         javalang library """
-    tree = javalang.parse.parse(javaString)
+    tree = javalang.parse.parse(java_string)
     data = list(tree.filter(javalang.tree.VariableDeclaration))
     num = len(data)
     return num
 
 
-def getNumberOfMethods(javaString):
+def get_number_of_methods(java_string):
     """ Counts number of methods in java code string using javalang library """
-    tree = javalang.parse.parse(javaString)
+    tree = javalang.parse.parse(java_string)
     data = list(tree.filter(javalang.tree.MethodDeclaration))
     num = len(data)
     return num
 
 
-def getNumberOfClasses(javaString):
+def get_number_of_classes(java_string):
     """ Counts number of defined classes in java code string using
         javalang library """
-    tree = javalang.parse.parse(javaString)
+    tree = javalang.parse.parse(java_string)
     data = list(tree.filter(javalang.tree.ClassDeclaration))
     num = len(data)
     return num
 
 
-def getNumberOfLines(javaString):
+def get_number_of_lines(java_string):
     """ Counts number of lines in java code. We consider any semicolons, open
         brackets, and closed brakets new line starts. Excludes empty lines. """
     num = 0
-    for c in javaString:
-        if c == ';' or c == '{' or c == '}':
+    for char in java_string:
+        if char == ';' or char == '{' or char == '}':
             num += 1
     return num

--- a/java_to_string.py
+++ b/java_to_string.py
@@ -1,30 +1,28 @@
-# Importing regex library
+""" read java source code files and convert to strings """
+
 import re
 
 
-def read_and_convert(javaFile):
+def read_and_convert(java_file):
     """The read_and_convert function reads in a Java File
     and returns the source code from the file, including comments"""
-    with open(javaFile, 'r') as src:
+    with open(java_file, 'r') as src:
         source_code = src.read()
 
     return source_code
 
 
-def remove_comments(javaString):
+def remove_comments(java_string):
     """The remove_comments function removes all comments
     from the Java source code returned by read_and_convert.
     This function outputs the entire source code as a string
     with zero whitespaces"""
-    javaString = re.sub(
-        re.compile(
-            "(?<=/\*).*?(?=\*/)",
-            re.DOTALL),
-        "",
-        javaString)  # remove multiline comments of the form (/* comment */)
+    # remove multiline comments of the form (/* comment */)
+    java_string = re.sub(
+        re.compile(r"(?<=/\*).*?(?=\*/)", re.DOTALL), "", java_string)
     # remove all single line comments
-    javaString = re.sub(re.compile("//.*?\n"), "", javaString)
+    java_string = re.sub(re.compile("//.*?\n"), "", java_string)
     # replace a new line with a blank character
-    javaString = javaString.replace("\n", "")
-    javaString = javaString.replace("/**/", "")  # remove comment residue
-    return javaString
+    java_string = java_string.replace("\n", "")
+    java_string = java_string.replace("/**/", "")  # remove comment residue
+    return java_string

--- a/parse_args.py
+++ b/parse_args.py
@@ -3,14 +3,11 @@ import argparse
 
 
 def parse_args(args):
+    """ parse arguments inputted via command line """
     parser = argparse.ArgumentParser(
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-
     # specifies token for a specific repository
-    parser.add_argument('--token',
-                        help='GitHub API token',
-                        required=True)
-
+    parser.add_argument(
+        '--token', help='GitHub API token', required=True)
     args = parser.parse_args()
-
     return args

--- a/parse_comments.py
+++ b/parse_comments.py
@@ -58,7 +58,7 @@ def count_multiline_java_comments(java_string):
 def get_ratio_of_singleline_comments_to_source_code(java_string):
     """Get the ratio of singleline comments to the
         number of lines in the Java source code."""
-    total_number_of_lines = java_parser.getNumberOfLines(java_string)
+    total_number_of_lines = java_parser.get_number_of_lines(java_string)
     number_of_singleline_comments = count_singleline_java_comments(java_string)
     return float(number_of_singleline_comments / total_number_of_lines)
 
@@ -66,7 +66,7 @@ def get_ratio_of_singleline_comments_to_source_code(java_string):
 def get_ratio_of_multiline_comments_to_source_code(java_string):
     """Get the ratio of multiline comments to the
         number of lines in the Java source code."""
-    total_number_of_lines = java_parser.getNumberOfLines(java_string)
+    total_number_of_lines = java_parser.get_number_of_lines(java_string)
     number_of_multiline_comments = count_multiline_java_comments(java_string)
     return float(number_of_multiline_comments / total_number_of_lines)
 

--- a/statistics.py
+++ b/statistics.py
@@ -1,15 +1,21 @@
+""" statistical functions """
+
 import numpy as np
 
 
-def getStatistics(numericalList):
-    q75, q25 = np.percentile(numericalList, [75, 25])
+def get_statistics(numerical_list):
+    """ calculate various basic statistics """
+    q75, q25 = np.percentile(numerical_list, [75, 25])
     iqr = q75 - q25
-    statString = "min: " + str(np.min(numericalList)) + " max: " \
-        + str(np.max(numericalList)) + " mean: " + str(np.mean(numericalList)) \
-        + " StdDev: " + str(np.std(numericalList)) + " iqr: " + str(iqr)
-    return statString
+    stat_string = "min: " + \
+        str(np.min(numerical_list)) + " max: " + \
+        str(np.max(numerical_list)) + " mean: " + \
+        str(np.mean(numerical_list)) + " StdDev: " + \
+        str(np.std(numerical_list)) + " iqr: " + str(iqr)
+    return stat_string
 
 
-def printStatistics(dictionary):
+def print_statistics(dictionary):
+    """ pretty-print statistics dictionary """
     for key, values in dictionary.items():
-        print(key + "\n" + getStatistics(values))
+        print(key + "\n" + get_statistics(values))


### PR DESCRIPTION
The remaining `pylint` errors and warnings are either things I've dealt with in other pull requests that are waiting to get merged with `master`, or have valid excuses (like certain comments containing code snippets being flagged for line length).

So many variables / functions had to be renamed from camelCase to snake_case... the sheer number of changes I had to make throughout the project suggest that very few of us are running editors with linting asynchronously integrated.  Atom has several packages for this, and I personally use a plugin for Vim called `ale`, that works quite well.