### PR TITLE
implement analyze_comments function

### DIFF
--- a/analyze_comments.py
+++ b/analyze_comments.py
@@ -1,0 +1,79 @@
+""" analyze java source code comments """
+
+
+from analyze_java import get_java_strings
+from analyze_sentiment import get_avg_sentiment
+import parse_comments as pc
+
+
+def analyze_comments(out):
+    """ produce cohesive analysis output regarding comments """
+    java_source = get_java_strings(out)
+
+    # accumulator vars
+    sum_count_javadoc = 0
+    sum_count_multiline = 0
+    sum_count_singleline = 0
+    sum_ratio_javadoc = 0
+    sum_ratio_multiline = 0
+    sum_ratio_singleline = 0
+    count_tracker = 0
+
+    # accumulate counts and ratios
+    for java_string in java_source:
+        sum_count_javadoc += pc.count_javadoc_java_comments(java_string)
+        sum_count_multiline += pc.count_multiline_java_comments(java_string)
+        sum_count_singleline += pc.count_singleline_java_comments(java_string)
+        sum_ratio_javadoc += pc.ratio_of_javadoc_comments(java_string)
+        sum_ratio_multiline += pc.ratio_of_multiline_comments(java_string)
+        sum_ratio_singleline += pc.ratio_of_singleline_comments(java_string)
+        count_tracker += 1  # track how many we've summed thus far
+
+    # convert summations to averages
+    avg_count_javadoc = sum_count_javadoc / count_tracker
+    avg_count_multiline = sum_count_multiline / count_tracker
+    avg_count_singleline = sum_count_singleline / count_tracker
+    avg_ratio_javadoc = sum_ratio_javadoc / count_tracker
+    avg_ratio_multiline = sum_ratio_multiline / count_tracker
+    avg_ratio_singleline = sum_ratio_singleline / count_tracker
+
+    # handle sentiment analysis
+    (singleline_comments, multiline_comments, javadoc_comments) = \
+        pc.get_all_comments(java_source)
+    avg_sentiment = get_avg_sentiment(singleline_comments + multiline_comments)
+
+    # FIXME: handle gensim analysis
+    gensim_analysis(javadoc_comments)
+
+    # format results for terminal printing
+    string_buffer = "\n" + \
+        "Singleline Comments\n" + \
+        "\tAverage Count: " + avg_count_singleline + \
+        "\tAverage Ratio: " + avg_ratio_singleline + \
+        "Multiline Comments\n" + \
+        "\tAverage Count: " + avg_count_multiline + \
+        "\tAverage Ratio: " + avg_ratio_multiline + \
+        "JavaDoc Comments\n" + \
+        "\tAverage Count: " + avg_count_javadoc + \
+        "\tAverage Ratio: " + avg_ratio_javadoc + \
+        "Average Sentiment: " + avg_sentiment
+    print(string_buffer)  # ... and print them
+
+    # format results for HTML embedding
+    html_buffer = "<br>" + \
+        "<b>Singleline Comments</b><ul>" + \
+        "<li>Average Count: " + avg_count_singleline + "</li>" + \
+        "<li>Average Ratio: " + avg_ratio_singleline + "</li>" + \
+        "</ul><b>Multiline Comments</b><ul>" + \
+        "<li>Average Count: " + avg_count_multiline + "</li>" + \
+        "<li>Average Ratio: " + avg_ratio_multiline + "</li>" + \
+        "</ul><b>JavaDoc Comments</b><ul>" + \
+        "<li>Average Count: " + avg_count_javadoc + "</li>" + \
+        "<li>Average Ratio: " + avg_ratio_javadoc + "</li></ul>" + \
+        "<b>Average Sentiment</b>: " + avg_sentiment
+
+    # ... and embed them
+
+    # FIXME: append html_buffer to generated LDA html page
+
+    # FIXME: automatically open gensim LDA html page?

--- a/analyze_comments.py
+++ b/analyze_comments.py
@@ -68,29 +68,29 @@ def analyze_comments(out):
     # format results for terminal printing
     string_buffer = "\n" + \
         "Singleline Comments\n" + \
-        "\tAverage Count: " + avg_count_singleline + \
-        "\tAverage Ratio: " + avg_ratio_singleline + \
+        "\tAverage Count: " + str(avg_count_singleline) + \
+        "\tAverage Ratio: " + str(avg_ratio_singleline) + \
         "Multiline Comments\n" + \
-        "\tAverage Count: " + avg_count_multiline + \
-        "\tAverage Ratio: " + avg_ratio_multiline + \
+        "\tAverage Count: " + str(avg_count_multiline) + \
+        "\tAverage Ratio: " + str(avg_ratio_multiline) + \
         "JavaDoc Comments\n" + \
-        "\tAverage Count: " + avg_count_javadoc + \
-        "\tAverage Ratio: " + avg_ratio_javadoc + \
-        "Average Sentiment: " + avg_sentiment
+        "\tAverage Count: " + str(avg_count_javadoc) + \
+        "\tAverage Ratio: " + str(avg_ratio_javadoc) + \
+        "Average Sentiment: " + str(avg_sentiment)
     print(string_buffer)  # ... and print them
 
     # format results for HTML embedding
     html_buffer = "<br>" + \
         "<b>Singleline Comments</b><ul>" + \
-        "<li>Average Count: " + avg_count_singleline + "</li>" + \
-        "<li>Average Ratio: " + avg_ratio_singleline + "</li>" + \
+        "<li>Average Count: " + str(avg_count_singleline) + "</li>" + \
+        "<li>Average Ratio: " + str(avg_ratio_singleline) + "</li>" + \
         "</ul><b>Multiline Comments</b><ul>" + \
-        "<li>Average Count: " + avg_count_multiline + "</li>" + \
-        "<li>Average Ratio: " + avg_ratio_multiline + "</li>" + \
+        "<li>Average Count: " + str(avg_count_multiline) + "</li>" + \
+        "<li>Average Ratio: " + str(avg_ratio_multiline) + "</li>" + \
         "</ul><b>JavaDoc Comments</b><ul>" + \
-        "<li>Average Count: " + avg_count_javadoc + "</li>" + \
-        "<li>Average Ratio: " + avg_ratio_javadoc + "</li></ul>" + \
-        "<b>Average Sentiment</b>: " + avg_sentiment
+        "<li>Average Count: " + str(avg_count_javadoc) + "</li>" + \
+        "<li>Average Ratio: " + str(avg_ratio_javadoc) + "</li></ul>" + \
+        "<b>Average Sentiment</b>: " + str(avg_sentiment)
 
     # ... and embed them
     # FIXME: append html_buffer to gensim html page

--- a/analyze_comments.py
+++ b/analyze_comments.py
@@ -6,9 +6,8 @@ from analyze_sentiment import get_avg_sentiment
 import parse_comments as pc
 
 
-def analyze_comments(out):
-    """ produce cohesive analysis output regarding comments """
-    java_source = get_java_strings(out)
+def calculate_averages(java_source):
+    """ calculate average comment counts and ratios """
 
     # accumulator vars
     sum_count_javadoc = 0
@@ -37,13 +36,34 @@ def analyze_comments(out):
     avg_ratio_multiline = sum_ratio_multiline / count_tracker
     avg_ratio_singleline = sum_ratio_singleline / count_tracker
 
+    return (
+        avg_count_javadoc,
+        avg_count_multiline,
+        avg_count_singleline,
+        avg_ratio_javadoc,
+        avg_ratio_multiline,
+        avg_ratio_singleline)
+
+
+def analyze_comments(out):
+    """ produce cohesive analysis output regarding comments """
+    java_source = get_java_strings(out)
+
+    # calculate averages
+    (avg_count_javadoc,
+     avg_count_multiline,
+     avg_count_singleline,
+     avg_ratio_javadoc,
+     avg_ratio_multiline,
+     avg_ratio_singleline) = \
+        calculate_averages(java_source)
+
     # handle sentiment analysis
-    (singleline_comments, multiline_comments, javadoc_comments) = \
-        pc.get_all_comments(java_source)
-    avg_sentiment = get_avg_sentiment(singleline_comments + multiline_comments)
+    (singleline, multiline, javadoc) = pc.get_all_comments(java_source)
+    avg_sentiment = get_avg_sentiment(singleline + multiline)
 
     # FIXME: handle gensim analysis
-    gensim_analysis(javadoc_comments)
+    gensim_analysis(javadoc)
 
     # format results for terminal printing
     string_buffer = "\n" + \
@@ -73,7 +93,5 @@ def analyze_comments(out):
         "<b>Average Sentiment</b>: " + avg_sentiment
 
     # ... and embed them
-
-    # FIXME: append html_buffer to generated LDA html page
-
-    # FIXME: automatically open gensim LDA html page?
+    # FIXME: append html_buffer to gensim html page
+    # FIXME: automatically open gensim html page

--- a/parse_comments.py
+++ b/parse_comments.py
@@ -45,7 +45,8 @@ def list_multiline_java_comments(java_string):
 def list_javadoc_comments(java_string):
     """Count the number of javadoc comments in the java_string."""
     pattern = re.compile(JAVADOC_COMMENT_RE, re.MULTILINE)
-    multiline_comments = pattern.findall(java_string)
+    tag_nixed_string = nix_javadoc_tags(java_string)
+    multiline_comments = pattern.findall(tag_nixed_string)
     trimmed_comments = []
     for comment in multiline_comments:
         trimmed_comments.append(comment.strip().strip('* '))


### PR DESCRIPTION
Addresses issue #57, implementing the `analyze_comments` function.

Not yet ready for merge, due to not knowing the specifics of the `gensim_analysis` function.
Missing functionality marked with `FIXME` comments.