### PR TITLE
implement get_ratios_of_comments function

### DIFF
--- a/parse_comments.py
+++ b/parse_comments.py
@@ -102,3 +102,11 @@ def ratio_of_javadoc_comments(java_string):
     total_number_of_lines = java_parser.get_number_of_lines(java_string)
     number_of_javadoc_comments = count_javadoc_java_comments(java_string)
     return float(number_of_javadoc_comments / total_number_of_lines)
+
+
+def get_ratios_of_comments(java_string):
+    """Return dictionary of comment ratios in the java_string."""
+    return {
+        "singleline": round(ratio_of_singleline_comments(java_string), 2),
+        "multiline": round(ratio_of_multiline_comments(java_string), 2),
+        "javadoc": round(ratio_of_javadoc_comments(java_string), 2)}


### PR DESCRIPTION
Addresses issue #53, implementing the `get_ratios_of_comments` function.

There are apparently some cases where rounding the floats to two decimal places won't work, but they are rare enough that this solution should work just fine.  The alternative would be to return strings instead, but other parts of the system would likely need changed to reflect the change of datatype, so this seems cleaner. 